### PR TITLE
fix php version

### DIFF
--- a/package.yml
+++ b/package.yml
@@ -1,5 +1,5 @@
 package: accessdenied
-version: '1.0.6'
+version: '1.0.7'
 author: Friends Of REDAXO
 supportpage: github.com/FriendsOfREDAXO/accessdenied
 
@@ -8,4 +8,4 @@ requires:
         structure: '^2.1.0'
     redaxo: '^5.1.0'
     php:
-        version: '^5.6'
+        version: '^7.0'


### PR DESCRIPTION
> AddOn accessdenied konnte aus folgendem Grund nicht installiert werden:
Die PHP-Version (7.4.5) entspricht nicht der geforderten Versionsbedingung ^5.6!