### PR TITLE
Fix: Behebe Timing-Problem beim Laden der Status-Typen (v3.0.1)

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -25,15 +25,15 @@ if (rex::isBackend()) {
 
     // Register sidebar extension via extension point to avoid early category/article access
     rex_extension::register('PACKAGES_INCLUDED', static function() {
-        $catclocked = false;
+        $catlocked = false;
         $cat = rex_category::getCurrent();
         $package = rex_addon::get('accessdenied');
         // Check inherit category status
         if ($package->getConfig('inherit') == true && $cat && $cat->getClosest(fn (rex_category $cat) => 2 == $cat->getValue('status'))) {
-            $catclocked = true;
+            $catlocked = true;
         }
         $art = rex_article::getCurrent();
-        if ($art && $art->getValue('status') == 2 || true == $catclocked) {
+        if ($art && $art->getValue('status') == 2 || true == $catlocked) {
             rex_extension::register('STRUCTURE_CONTENT_SIDEBAR', [Accessdenied::class, 'addContentSidebar']);
         }
     }, rex_extension::LATE);

--- a/package.yml
+++ b/package.yml
@@ -1,5 +1,5 @@
 package: accessdenied
-version: '3.0.0'
+version: '3.0.1'
 author: Friends Of REDAXO
 supportpage: github.com/FriendsOfREDAXO/accessdenied
 requires:


### PR DESCRIPTION
- Extension Point mit rex_extension::EARLY Priorität registrieren
- Category/Article-Zugriff in PACKAGES_INCLUDED Extension Point verschieben
- Verhindert 'Undefined array key 2' Warnings beim Zugriff auf gesperrte Artikel/Kategorien