### PR TITLE
fix: PHP-Mindestanforderung auf 8.3 gesenkt, array_find() durch in_ar…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 4.0.1 (2026-05-05)
+
+### Fehlerbehebungen
+- PHP-Mindestanforderung von `>=8.4` auf `>=8.3` gesenkt — `array_find()` wurde durch `in_array()` ersetzt
+
 ## 4.0.0 (2026-03-30)
 
 ### Breaking Changes

--- a/lib/accessdenied.php
+++ b/lib/accessdenied.php
@@ -75,7 +75,7 @@ class Accessdenied
             return false;
         }
         $ips = array_map('trim', explode("\n", $whitelist));
-        return array_find($ips, static fn(string $ip) => $ip === $clientIp) !== null;
+        return in_array($clientIp, $ips, true);
     }
 
     public static function handleFrontendRedirect(): void

--- a/package.yml
+++ b/package.yml
@@ -1,5 +1,5 @@
 package: accessdenied
-version: '4.0.0'
+version: '4.0.1'
 author: Friends Of REDAXO
 supportpage: github.com/FriendsOfREDAXO/accessdenied
 requires:
@@ -7,7 +7,7 @@ requires:
         structure/content: '^2.1.0'
     redaxo: '^5.10.0'
     php:
-        version: '>=8.4'
+        version: '>=8.3'
     
 conflicts:
     packages:


### PR DESCRIPTION
…ray() ersetzt